### PR TITLE
fix cards not flipping when Astro view transitions enabled

### DIFF
--- a/src/components/features.astro
+++ b/src/components/features.astro
@@ -98,13 +98,9 @@ const coralComponents = [
 ---
 
 <script>
-  // When Astro View Transitions is enabled, the astro:page-load event listener has to be used 
-  // to execute code that would otherwise normally execute on DOMContentLoaded event.
-  document.addEventListener('astro:page-load', () => {
-    document.querySelectorAll('.flip-card').forEach(card => {
-      card.addEventListener('click', () => {
-        card.classList.toggle('flipped');
-      });
+  document.querySelectorAll('.flip-card').forEach(card => {
+    card.addEventListener('click', () => {
+      card.classList.toggle('flipped');
     });
   });
 </script>
@@ -122,8 +118,8 @@ const coralComponents = [
           <Icon class="text-white" name={item.icon} />
         </div>
         <div>
-          <h3 class="font-semibold text-lg">{item.title}</h3>{" "}
-          <p class="hidden lg:block mt-2 text-slate-600 leading-relaxed">{item.description}</p>
+          <div class="font-semibold text-lg">{item.title}</div>{" "}
+          <div class="hidden lg:block mt-2 text-slate-600 leading-relaxed">{item.description}</div>
         </div>
       </div>
     ))

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,7 +4,6 @@ import Footer from "@components/footer.astro";
 import Navbar from "@components/navbar/navbar.astro";
 import "@fontsource-variable/inter/index.css";
 import "../styles/global.css";
-import { ClientRouter } from "astro:transitions";
 
 export interface Props {
   title: string;
@@ -42,8 +41,6 @@ const seoImage = image ? new URL(image, Astro.site).toString() : defaultImage;
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/logo_no_dual.svg" />
     <meta name="generator" content={Astro.generator} />
-
-    <ClientRouter />
 
     <SEO
       title={makeTitle}


### PR DESCRIPTION
closes #35 

From [official documentation](https://docs.astro.build/en/reference/modules/astro-transitions/#astropage-load-event)
> astro:page-load event
[...]
When view transitions is enabled on the page, code that would normally execute on DOMContentLoaded should be changed to execute on this event.

Considering the complexity introduced by handling this case (and others in the future) and considering that the Astro view transitions fading effect gives the impression of a slower rendering speed, we decided to remove it.